### PR TITLE
Add log-seeker build workflow

### DIFF
--- a/.github/workflows/log-seeker-build.yaml
+++ b/.github/workflows/log-seeker-build.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2024 Free Software Foundation Europe e.V. <https://fsfe.org>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: Go Build
+
+on:
+    push:
+    # Run on branch/tag creation
+    create:
+    # Run on pull requests
+    pull_request:
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+
+            - name: Set up Go
+              uses: actions/setup-go@v2
+              with:
+                  go-version: '1.22.0'
+
+            - name: Install dependencies
+              run: go mod tidy
+
+            - name: Build
+              run: go build -v .


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the build process for a Go project. The workflow is triggered on pushes, branch/tag creations, and pull requests.

GitHub Actions workflow:

* [`.github/workflows/log-seeker-build.yaml`](diffhunk://#diff-8157e9d4a14500f234011e81c3e2ce909d64ca3e71b6ef18287184771a7a0609R1-R28): Added a new workflow named "Go Build" that sets up the environment, installs dependencies, and builds the Go project.
*  #2